### PR TITLE
Fix a hidden problem that came up to the surface on OTP 18.0

### DIFF
--- a/c_src/encode.c
+++ b/c_src/encode.c
@@ -370,17 +370,19 @@ encode(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     yajl_gen_config config = {0, NULL};
     yajl_gen handle = yajl_gen_alloc(&config, NULL);
     yajl_gen_status status;
-    ERL_NIF_TERM ret = enif_make_badarg(env);
+    ERL_NIF_TERM ret;
     ErlNifBinary bin;
     const unsigned char* json;
     unsigned int jsonlen;
     
     if( argc != 2 )
     {
+        ret = enif_make_badarg(env);
         goto done;
     }
     if( !enif_is_list(env, argv[1]) )
     {
+        ret = enif_make_badarg(env);
         goto done;
     }
 


### PR DESCRIPTION
enif_make_badarg() is very special. Once you call it, it changes the internal state of ErlNifEnv so that the runtime can raise a badarg when the NIF returns. Prior to OTP 18.0, you could actually call it and then create another ERL_NIF_TERM to return, while the documentation [*1] was clearly saying that you must not do that. This has been in fact an undefined behavior, and has changed in OTP 18.0; once you call it, the runtime always raises a badarg regardless of what your NIF returns.

*1: http://www.erlang.org/doc/man/erl_nif.html#enif_make_badarg
